### PR TITLE
feat: #103 revision of reset db script

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   pt-general:
     dependencies:
+      '@faker-js/faker':
+        specifier: ^9.9.0
+        version: 9.9.0
       axios:
         specifier: 1.11.0
         version: 1.11.0
@@ -188,10 +191,10 @@ importers:
         specifier: 22.12.0
         version: 22.12.0
       '@types/react':
-        specifier: 19.1.8
+        specifier: ^19.1.8
         version: 19.1.8
       '@types/react-dom':
-        specifier: 19.1.6
+        specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
       '@typescript-eslint/eslint-plugin':
         specifier: 8.38.0
@@ -1052,6 +1055,10 @@ packages:
   '@eslint/plugin-kit@0.3.4':
     resolution: {integrity: sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@faker-js/faker@9.9.0':
+    resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
+    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -5707,6 +5714,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.1
       levn: 0.4.1
+
+  '@faker-js/faker@9.9.0': {}
 
   '@humanfs/core@0.19.1': {}
 

--- a/pt-general/package.json
+++ b/pt-general/package.json
@@ -22,6 +22,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@faker-js/faker": "^9.9.0",
     "axios": "1.11.0",
     "bcryptjs": "2.4.3",
     "cloudinary": "2.7.0",
@@ -30,11 +31,11 @@
     "envalid": "8.1.0",
     "express": "5.1.0",
     "jsonwebtoken": "9.0.2",
+    "lint-staged": "15.2.2",
     "multer": "2.0.2",
     "multer-storage-cloudinary": "4.0.0",
     "swagger-jsdoc": "6.2.8",
-    "swagger-ui-express": "5.0.1",
-    "lint-staged": "15.2.2"
+    "swagger-ui-express": "5.0.1"
   },
   "devDependencies": {
     "@eslint/js": "9.32.0",

--- a/pt-general/src/scripts/README.md
+++ b/pt-general/src/scripts/README.md
@@ -2,21 +2,16 @@
 
 1. reset.ts
 
-This script seeds the PostgreSQL database with initial demo data using Prisma.
+This script seeds the PostgreSQL database with initial demo data using Prisma and @faker-js/faker for generating random content.
 
-What it does:
+What it does: 
 
-Creates default categories and tags
+- Creates 5 categories and 5 tags
+- Adds 20 users, including 5 guides
+- Creates 20 tours, each linked to a random guide, category, and tag
+- Generates 40 tour dates (some available, some unavailable)
+- Tour titles and descriptions are randomized for more realistic demo data
 
-Adds two users with the GUIDE role
-
-Adds two guides linked to those users
-
-Creates two tours (each linked to a guide)
-
-Connects each tour to one category and one tag
-
-Adds available/unavailable tour dates
 
 2. Run the script with the appropriate loader:
 

--- a/pt-general/src/scripts/reset.ts
+++ b/pt-general/src/scripts/reset.ts
@@ -1,5 +1,6 @@
 import {DifficultyLevel, PrismaClient, Role} from 'src/generated/prisma';
 import {logger} from 'src/utils/logger.js';
+import {faker} from '@faker-js/faker';
 
 const prisma = new PrismaClient();
 
@@ -19,6 +20,56 @@ async function clearDatabase() {
   await prisma.category.deleteMany();
   await prisma.tag.deleteMany();
   await prisma.promoCode.deleteMany();
+}
+
+const DEFAULT_TOUR_DAYS = 3;
+const INCLUSIVE_OFFSET = 1;
+
+const START_HOUR_MIN = 9;
+const START_HOUR_MAX_OFFSET = 4;
+const END_HOUR_MIN = 17;
+const END_HOUR_MAX_OFFSET = 3;
+
+const FIRST_DAY_INDEX = 1;
+
+const NUMBER_OF_CLIENTS = 15;
+const NUMBER_OF_GUIDES = 5;
+
+const MIN_EXPERIENCE_YEARS = 2;
+const MAX_ADDITIONAL_EXPERIENCE_YEARS = 5;
+
+const PRICE_MIN = 1000;
+const PRICE_MAX = 5000;
+
+const TOURS_COUNT = 20;
+const TOUR_PROGRAM_DAYS = 5;
+const DATE_SOON_1 = 30;
+const DATE_SOON_2 = 60;
+const DATE_AVAILABILITY_PROB = 0.5;
+
+function getRandomItem<T>(array: T[]): T {
+  return array[Math.floor(Math.random() * array.length)];
+}
+
+function getRandomPrice(min: number, max: number): number {
+
+  return Math.floor(Math.random() * (max - min + INCLUSIVE_OFFSET)) + min;
+}
+
+function generateTourProgram(daysCount: number = DEFAULT_TOUR_DAYS): string[] {
+  const activities = [
+    'mountain hiking', 'historical site tour', 'kayaking',
+    'local market visit', 'cultural workshop',
+    'sunset photoshoot', 'city bike tour', 'local cuisine tasting',
+  ];
+  const program: string[] = [];
+  for (let i = FIRST_DAY_INDEX; i <= daysCount; i++) {
+    const time = `${START_HOUR_MIN + Math.floor(Math.random()
+       * START_HOUR_MAX_OFFSET)}:00 - ${END_HOUR_MIN + Math.floor(Math.random() * END_HOUR_MAX_OFFSET)}:00`;
+    program.push(`Day ${i} (${time}): ${getRandomItem(activities)}`);
+  }
+
+  return program;
 }
 
 async function seedDatabase() {
@@ -42,113 +93,112 @@ async function seedDatabase() {
     prisma.tag.create({data: {name: 'Photography'}}),
   ]);
 
-  await Promise.all([
-    prisma.user.create({
+  const clientPromises = [];
+  for (let i = 0; i < NUMBER_OF_CLIENTS; i++) {
+    clientPromises.push(
+      prisma.user.create({
+        data: {
+          email: faker.internet.email(),
+          firstName: faker.person.firstName(),
+          lastName: faker.person.lastName(),
+          password: 'hashedpassword',
+          role: Role.CLIENT,
+        },
+      }),
+    );
+  }
+  await Promise.all(clientPromises);
+
+  const guideUsers = [];
+  for (let i = 0; i < NUMBER_OF_GUIDES; i++) {
+    const user = await prisma.user.create({
       data: {
-        email: 'client1@example.com',
-        firstName: 'Client One',
-        lastName: 'Client One lastName',
+        email: faker.internet.email(),
+        firstName: faker.person.firstName(),
+        lastName: faker.person.lastName(),
         password: 'hashedpassword',
-        role: Role.CLIENT,
+        role: Role.GUIDE,
       },
-    }),
-    prisma.user.create({
-      data: {
-        email: 'client2@example.com',
-        firstName: 'Client Two',
-        lastName: 'Client two last Name',
-        password: 'hashedpassword',
-        role: Role.CLIENT,
-      },
-    }),
-  ]);
+    });
+    guideUsers.push(user);
+  }
 
-  const guideUser = await prisma.user.create({
-    data: {
-      email: 'guide@example.com',
-      firstName: 'Guide Person',
-      lastName: 'Guide Person last name',
-      password: 'hashedpassword',
-      role: Role.GUIDE,
-    },
-  });
+  const guides = [];
+  for (const user of guideUsers) {
+    guides.push(
+      await prisma.guide.create({
+        data: {
+          userId: user.id,
+          experience: `${MIN_EXPERIENCE_YEARS + Math.floor(Math.random() * MAX_ADDITIONAL_EXPERIENCE_YEARS)} years guiding tours`,
+          specializations: [
+            getRandomItem(categories).name,
+            getRandomItem(categories).name,
+          ],
+        },
+      }),
+    );
+  }
 
-  const guideUser2 = await prisma.user.create({
-    data: {
-      email: 'secondguide@example.com',
-      firstName: 'Second Guide',
-      lastName: 'Second Guide last name',
-      password: 'hashedpassword2',
-      role: Role.GUIDE,
-    },
-  });
+  const difficultyLevels = [
+    DifficultyLevel.BEGINNER,
+    DifficultyLevel.PRO,
+    DifficultyLevel.EXPERIENCED,
+  ];
 
-  const guide2 = await prisma.guide.create({
-    data: {
-      userId: guideUser2.id,
-      experience: '3 years guiding city tours',
-      specializations: ['City', 'Culture'],
-    },
-  });
+  const FIRST_CHAR_INDEX = 0;
+  const SECOND_CHAR_INDEX = 1;
 
-  const guide = await prisma.guide.create({
-    data: {
-      userId: guideUser.id,
-      experience: '5 years guiding mountain tours',
-      specializations: ['Nature', 'Mountains'],
-    },
-  });
+  function capitalizeFirstLetter(str: string) {
+    return str.charAt(FIRST_CHAR_INDEX).toUpperCase() + str.slice(SECOND_CHAR_INDEX);
+  }
 
-  const [natureCategory, cityCategory] = categories;
-  const [sunsetTag, wildlifeTag] = tags;
+  const tourPromises = [];
+  for (let i = 0; i < TOURS_COUNT; i++) {
+    const guide = getRandomItem(guides);
+    const category = getRandomItem(categories);
+    const tag = getRandomItem(tags);
 
-  await prisma.tour.create({
-    data: {
-      title: 'Mountain Adventure',
-      description: 'Exciting mountain hiking tour',
-      region: 'Alps',
-      difficulty: DifficultyLevel.BEGINNER,
-      price: 250,
-      program: {days: ['Day 1: Arrival', 'Day 2: Hiking']},
-      guideId: guide.id,
-      categories: {connect: [{id: natureCategory.id}]},
-      tags: {connect: [{id: sunsetTag.id}]},
-      dates: {
-        create: [
-          {date: new Date('2025-08-15'), isAvailable: true},
-          {date: new Date('2025-09-15'), isAvailable: false},
-        ],
-      },
-    },
-  });
+    const adjective = capitalizeFirstLetter(faker.word.adjective({length: {min: 5, max: 10}}));
 
-  await prisma.tour.create({
-    data: {
-      title: 'City Exploration',
-      description: 'Explore the best parts of the city',
-      region: 'Paris',
-      difficulty: DifficultyLevel.EXPERIENCED,
-      price: 150,
-      program: {days: ['Day 1: Museum visit', 'Day 2: City walk']},
-      guideId: guide2.id,
-      categories: {connect: [{id: cityCategory.id}]},
-      tags: {connect: [{id: wildlifeTag.id}]},
-      dates: {
-        create: [
-          {date: new Date('2025-08-20'), isAvailable: true},
-          {date: new Date('2025-09-10'), isAvailable: true},
-        ],
-      },
-    },
-  });
+    const titleTemplates = [
+      `${adjective} ${category.name}`,
+      `${adjective} ${category.name} Journey`,
+      `${adjective} ${category.name} Experience`,
+    ];
 
-  logger.info('Database has been seeded.');
+    tourPromises.push(
+      prisma.tour.create({
+        data: {
+          title: getRandomItem(titleTemplates),
+          description: `Join this ${category.name} tour and discover unique experiences in the region of 
+          ${faker.location.city()}, ${faker.location.country()}.`,
+          region: faker.location.city(),
+          difficulty: getRandomItem(difficultyLevels),
+          price: getRandomPrice(PRICE_MIN, PRICE_MAX),
+          program: {text: generateTourProgram(TOUR_PROGRAM_DAYS)},
+          guideId: guide.id,
+          categories: {connect: [{id: category.id}]},
+          tags: {connect: [{id: tag.id}]},
+          dates: {
+            create: [
+              {date: faker.date.soon({days: DATE_SOON_1}), isAvailable: true},
+              {date: faker.date.soon({days: DATE_SOON_2}), isAvailable: Math.random() > DATE_AVAILABILITY_PROB},
+            ],
+          },
+        },
+      }),
+    );
+  }
+
+  await Promise.all(tourPromises);
+
+  logger.info('Database has been seeded with realistic tours!');
   await prisma.$disconnect();
 }
 
 const EXIT_ERROR_CODE = 1;
 
-seedDatabase().catch(e => {
+seedDatabase().catch((e) => {
   logger.error('Error during database reset:', e);
   prisma.$disconnect();
   process.exit(EXIT_ERROR_CODE);


### PR DESCRIPTION
I refined the **reset:db script.**
Now it creates 20 tours with different names, 40 dates, 20 users, including 5 guides, 5 categories, and 5 tags. I added the @faker-js/faker library to generate fake random data.